### PR TITLE
Fix two Xyce- and ADMS-specific issues

### DIFF
--- a/ekv26_SDext_Verilog-A.va
+++ b/ekv26_SDext_Verilog-A.va
@@ -105,7 +105,7 @@ enddiscipline
 `define FWD 1
 `define REV -1
 // AB 040902
-`define NOT_GIVEN -1.0e21
+`define NOT_GIVEN 1.0e21
 `define DEFAULT_TNOM 25
 module ekv_va(d,g,s,b);
     // %%DEVICE_CLASS=MOS(NMOS:TYPE=1,PMOS:TYPE=-1)%%
@@ -208,10 +208,10 @@ module ekv_va(d,g,s,b);
     parameter integer TYPE = 1 from [-1:1] exclude 0; // NMOS=1, PMOS=-1
     parameter integer Noise = 1 from [0:1];     // Set to zero to prevent noise calculation
     parameter real Trise = 0.0 from [-inf:inf]; // Difference sim. temp and device temp [C deg]
-//  parameter real Temp = -`NOT_GIVEN from [`P_CELSIUS0:inf];  // Device temp [C]
+//  parameter real Temp = `NOT_GIVEN from [`P_CELSIUS0:inf];  // Device temp [C]
 //AB:  the parameter name Temp is not working for no obvious reason; changed to TEMP
-    parameter real TEMP = -`NOT_GIVEN from [`P_CELSIUS0:inf];  // Device temp [C]
-    parameter real TNOM = -`NOT_GIVEN; // Temperature [C]
+    parameter real TEMP = `NOT_GIVEN from [`P_CELSIUS0:inf];  // Device temp [C]
+    parameter real TNOM = `NOT_GIVEN; // Temperature [C]
     parameter real L = 10E-6 from [0.0:inf]; // Channel length [m]
     parameter real W = 10E-6 from [0.0:inf]; // Channel width [m]
     parameter real M = 1.0 from [0.0:inf]; // Parallel multiple device number
@@ -318,11 +318,11 @@ module ekv_va(d,g,s,b);
          */
         /* If Temp is explicitly specified, use that value
            otherwise use Tckt+Trise */
-        if (TEMP == -`NOT_GIVEN)	//AB: 040902 Temp -> TEMP
+        if (TEMP == `NOT_GIVEN)	//AB: 040902 Temp -> TEMP
             T = $temperature + Trise;
         else
             T = TEMP + `P_CELSIUS0;	//AB: 040902 Temp -> TEMP
-        if (TNOM == -`NOT_GIVEN)
+        if (TNOM == `NOT_GIVEN)
             Tnom = `DEFAULT_TNOM + `P_CELSIUS0;
         else
             Tnom = TNOM + `P_CELSIUS0;
@@ -748,8 +748,8 @@ module ekv_va(d,g,s,b);
             real S_flicker, S_thermal;
             S_thermal = 4 * `P_K * T * Gn;
             S_flicker = KF * gm * gm / (Weff * NS * Leff * COX);
-            I(ds) <+ white_noise(S_thermal, "thermal") +
-                flicker_noise(S_flicker, AF, "flicker");
+            I(ds) <+ white_noise(S_thermal, "thermal");
+            I(ds) <+ flicker_noise(S_flicker, AF, "flicker");
         end
         ///////////////////////////////////
         //EXTRINSIC PART: JUNCTION DIODES//


### PR DESCRIPTION
We tried to compile EKV 2.6 using ADMS for Xyce and ran into two issues.  Since these are simple and fixing them will not harm other simulator's ability to import EKV, we'd like to see them fixed in the official distribution.

ADMS does not appear to like this usage:

    `define NOT_GIVEN -1e21;
    variable=-`NOT_GIVEN;
    if (variable == -`NOT_GIVEN)

That's mainly because it winds up getting expanded  to "--1e21"
and the doubled minus causes problems. Specifically, ADMS pukes while
parsing the verilog-a:

 ./ekv26_SDext_Verilog-A.va: during lexical analysis syntax error at line 208 -- see '-'

This is not specific to Xyce's back-end, as it's happening as the
verilog-A itself is being parsed.

Since NOT_GIVEN is never, ever used anywhere in ekv except as
-`NOT_GIVEN, there's no real reason to carry around the extra unary
minus.

Secondly, Xyce/ADMS is not set up to handle noise contributions except
when they contain a single noise function.  EKV had one contribution
with both  flicker and white noise function in it.  Splitting that one
contribution into two makes Xyce/ADMS happy.